### PR TITLE
Refactor to use InvocationInfo

### DIFF
--- a/Tests/ConvertTo-Breakpoint.Tests.ps1
+++ b/Tests/ConvertTo-Breakpoint.Tests.ps1
@@ -1,16 +1,15 @@
 Describe "function ConvertTo-Breakpoint" {
     Mock Set-PSBreakpoint {return $true}
     It "Does not throw when there is no input" {
-        ConvertTo-Breakpoint -ErrorRecord @{ScriptStackTrace=''}
+        ConvertTo-Breakpoint -ErrorRecord @{InvocationInfo=''}
     }
 
     It "Does not throw" {
         $obj = [pscustomobject]@{
-            ScriptStackTrace = @'
-at New-Error, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 2
-at Get-Error, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 6
-at <ScriptBlock>, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 9
-'@
+            InvocationInfo = [pscustomobject]@{
+                ScriptLineNumber = 2
+                ScriptName = "C:\workspace\ConvertTo-Breakpoint\testing.ps1" 
+            }
         }
         $obj | ConvertTo-Breakpoint
         $obj | ConvertTo-Breakpoint -All
@@ -21,11 +20,10 @@ at <ScriptBlock>, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 9
 
     It "Does not throw with multiple objects" {
         $obj = [pscustomobject]@{
-            ScriptStackTrace = @'
-at New-Error, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 2
-at Get-Error, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 6
-at <ScriptBlock>, C:\workspace\ConvertTo-Breakpoint\testing.ps1: line 9
-'@
+            InvocationInfo = [PSCustomObject]@{
+                ScriptLineNumber = 2
+                ScriptName = "C:\workspace\ConvertTo-Breakpoint\testing.ps1" 
+            }
         }
         $array = @($obj,$obj,$obj)
         $array | ConvertTo-Breakpoint

--- a/module/private/ExtractBreakpoint.ps1
+++ b/module/private/ExtractBreakpoint.ps1
@@ -2,49 +2,33 @@ function ExtractBreakpoint
 {
     <#
     .DESCRIPTION
-    Parses a script stack trace for breakpoints
+    Extracts line number and scriptname for breakpoints
 
     .EXAMPLE
-    $error[0].ScriptStackTrace | ExtractBreakpoint
+    $error[0].InvocationInfo | ExtractBreakpoint
     #>
     [OutputType('System.Collections.Hashtable')]
     [cmdletbinding()]
     param(
-        # The ScriptStackTrace
+        # The InvocationInfo
         [parameter(
             ValueFromPipeline
         )]
         [AllowNull()]
         [AllowEmptyString()]
         [Alias('InputObject')]
-        [string]
-        $ScriptStackTrace
+        $InvocationInfo
     )
-
-    begin
-    {
-        $breakpointPattern = 'at .+, (?<Script>.+): line (?<Line>\d+)'
-    }
 
     process
     {
-        if (-not [string]::IsNullOrEmpty($ScriptStackTrace))
+        if (-not [string]::IsNullOrEmpty($InvocationInfo.ScriptName) -and 
+            (Test-Path $InvocationInfo.ScriptName))
         {
-            $lineList = $ScriptStackTrace -split [System.Environment]::NewLine
-            foreach($line in $lineList)
-            {
-                if ($line -match $breakpointPattern)
-                {
-                    if ($matches.Script -ne '<No file>' -and 
-                        (Test-Path $matches.Script))
-                    {
-                        @{
-                            Script = $matches.Script
-                            Line   = $matches.Line
-                        }                                
-                    }
-                }
-            }
-        }
+            @{
+                Script = $InvocationInfo.ScriptName
+                Line   = $InvocationInfo.ScriptLineNumber
+            }                                
+        }       
     }
 }

--- a/module/public/ConvertTo-Breakpoint.ps1
+++ b/module/public/ConvertTo-Breakpoint.ps1
@@ -34,7 +34,7 @@ function ConvertTo-Breakpoint
     {
         foreach ($node in $ErrorRecord)
         {
-            $breakpointList = $node.ScriptStackTrace | ExtractBreakpoint
+            $breakpointList = $node.InvocationInfo | ExtractBreakpoint
 
             foreach ($breakpoint in $breakpointList)
             {
@@ -47,7 +47,7 @@ function ConvertTo-Breakpoint
                         break
                     }
                 }
-            }                
+            }               
         }
     }
 }


### PR DESCRIPTION
Hello Kevin,

I found your ConvertTo-Breakpoint on Twitter, and I liked the idea! When I played with it, I started wondering if the same could be done with the InvocationInfo property of the ErrorRecord, instead of parsing the ScriptStackTrace. It seems to work that way too, although I don't think it is 100% the same: it seems ScriptStackTrace can possibly give back more than one line, and InvocationInfo only gives back one line. 
Having said that, I thought I should share this with you, maybe you like it.

Please note, I am not a frequent GitHubber, so constructive feedback on process and/or code is welcomed :-) The process of uploading my changes from VSCode back to my repo ended badly. It may be my 2fa, I'm not sure. I had to upload the three changed files by hand, and that went klunky. That explains the messy commit-trail.

(find me on twitter at @Jawz_84, on GitHub it's @Jawz84, without underscore)